### PR TITLE
Add non_us_pound to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Once you have built the installable package:
 1. Open the DMG file and follow the instructions.
 2. Open Karabiner-Elements and add the following “Simple Modifications”:
    * `backslash (\)` to `right_option` (on some external keyboards it might be
-     necessary to remap `non_us_backslash` instead of `backslash (\)`)
+     necessary to remap `non_us_backslash` or `non_us_pound` instead of `backslash (\)`)
    * `caps_lock` to `right_option`
    * ``grave_accent_and_tilde (`)`` to `right_command`
    * `right_option` to `left_command`

--- a/README_de.md
+++ b/README_de.md
@@ -39,7 +39,7 @@ Nach dem Bauen des Pakets folgt die eigentliche Installation und Konfiguration:
 1. Öffne die DMG-Datei und folge den Anweisungen des darin enthaltenen Installers.
 2. Öffne Karabiner-Elements and füge unter „Simple Modifications“ folgende Einträge hinzu:
    * `backslash (\)` zu `right_option` (bei manchen externen Tastaturen kann es
-     nötig sein `non_us_backslash` statt `backslash (\)` um zu belegen)
+     nötig sein, `non_us_backslash` oder `non_us_pound` statt `backslash (\)` um zu belegen)
    * `caps_lock` zu `right_option`
    * ``grave_accent_and_tilde (`)`` zu `right_command`
    * `right_option` zu `left_command`


### PR DESCRIPTION
Logitech K740 requires `non_us_pound` to address the mod3 key on the right hand side.